### PR TITLE
v2

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,2 @@
 node_modules/
-lib/
 *.log
-*.min.js

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 2.0.0
+
+This major release brings about a few API changes and wider browser support.
+
+API changes are limited to Choice.Selection; the `absoluteStart`, `absoluteEnd`, `isCollapsed`, and `isBackwards` methods have instead been turned into getters. This means that the following code:
+
+```js
+var c = new Choice(someElement)
+var s = c.getSelection()
+
+var isCollapsed = s.isCollapsed()
+var isBackwards = s.isBackwards()
+var absoluteStart = s.absoluteStart()
+var absoluteEnd = s.absoluteEnd()
+```
+
+Should, in `v2` onwards, be written as:
+
+```js
+var c = new Choice(someElement)
+var s = c.getSelection()
+
+var isCollapsed = s.isCollapsed // Not a function call
+var isBackwards = s.isBackwards
+var absoluteStart = s.absoluteStart
+var absoluteEnd = s.absoluteEnd
+```
+
+Additionally, Choice now works in browsers without the native `Selection#extend` method (namely, Internet Explorer).
+
 ## 1.4.0
 
 - Added `Selection#absoluteStart()` and `Selection#absoluteEnd()`.

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ Choice represents the endpoints of a selection as an integer pair `[childIndex, 
 
 ## API
 
-### new Choice( element [, getChildren ] )
+### new Choice( element[, getChildren ] )
 
-Creates an instance of Choice. The `new` constructor is optional. `element` is the root `contenteditable` element that represent the “document” of the editor.
+Creates an instance of Choice. `element` is the root `contenteditable` element that represent the “document” of the editor.
 
 Although working with child indices may work for simple use cases, like the example above, the shortcomings of that method quickly become evident when your editor produces more complex markup. Consider:
 
@@ -54,7 +54,7 @@ Although working with child indices may work for simple use cases, like the exam
 </article>
 ```
 
-In this case, using child indices wouldn’t work; the “blocks” of text aren’t direct children of the “document”. For these situations, Choice takes a second paramater, `getChildren`, a function that return an array containing the relevant “blocks” of text. For the above example, `getChildren` might look like:
+In this case, using child indices wouldn’t work; the “blocks” of text aren’t direct children of the “document”. For these situations, Choice takes a second parameter, `getChildren`, a function that return an array containing the relevant “blocks” of text. For the above example, `getChildren` might look like:
 
 ```js
 function getChildren() {
@@ -69,17 +69,13 @@ If a `getChildren` function is not given, Choice defaults to using the root elem
 
 ### Choice#getSelection( )
 
-Returns an an instance of `Choice.Selection`. This has two properties, `start` and `end`, which contain the two integer pairs representing the start and end points of the selection. See below for more information on `Choice.Selection`.
+Returns an an instance of [`Choice.Selection`](#selection). This has two properties, `start` and `end`, which contain the two integer pairs representing the start and end points of the selection. See below for more information on `Choice.Selection`.
 
 If the user’s selection is not contained within the root element, `getSelection` returns `null`.
 
 ### Choice#restore( savedSelection )
 
-Sets the user’s selection to match that represented by the given instance of `Choice.Selection`.
-
-### Choice.support( )
-
-This method returns true if the APIs Choice relies on exist. See [Browser support](#browser-support) below.
+Sets the user’s selection to match that represented by the given instance of [`Choice.Selection`](#selection).
 
 <hr>
 
@@ -95,21 +91,21 @@ An array containing the integer pair corresponding to the start of the selection
 
 An array containing the integer pair corresponding to the end of the selection.
 
-#### Selection#absoluteStart( )
+#### Selection#absoluteStart
 
-In a right-to-left selection, `Selection#start` is after `Selection#end`. `Selection#absoluteStart()` returns the endpoint that occurs first, visually, in the document.
+In a right-to-left selection, `Selection#start` is after `Selection#end`. `Selection#absoluteStart` is a getter that returns the endpoint that occurs first, visually, in the document.
 
-#### Selection#absoluteEnd( )
+#### Selection#absoluteEnd
 
 As above, but returns the last endpoint.
 
-#### Selection#isCollapsed( )
+#### Selection#isCollapsed
 
-Returns a boolean indicating whether the endpoints of the selection are identical.
+Getter that returns a boolean indicating whether the endpoints of the selection are identical.
 
-#### Selection#isBackwards( )
+#### Selection#isBackwards
 
-Returns a boolean indicating whether the selection represents a right-to-left selection.
+Getter that returns a boolean indicating whether the selection represents a selection in the direction opposite to the text direction.
 
 #### Selection#clone( )
 
@@ -176,11 +172,34 @@ Naively swapping the paragraph for a heading would (probably, depending on the b
 
 There are some restriction to saving and restoring the selection. Anything that would mess up the integer pairs representing the endpoints of the selection will result in a poorly restored selection. This includes, but may not be limited to, inserting/removing “blocks” or inserting/removing text. If you plan on doing those things, you should update the saved selection manually to account for your changes.
 
-Additionally, Firefox, for whatever reason, allows multiple selections in `contenteditable` regions. Choice has inconsistent behaviour when there are multiple selection regions. My advice? It’s not worth fussing over.
-
 ## Browser support
 
-Unfortunately, Choice only works in browsers that implement the native [`Selection#extend`][extend] method. Essentially, that’s all major browsers except Internet Explorer.
+Choice works best in browsers implement the native [`Selection#extend`][extend] method (all browsers except Internet Explorer). In Internet Explorer, Choice identically except that restored selections do not have any directionality. See the following for an example of what this means:
+
+```html
+<!-- Starting with a collapsed selection: -->
+<p>12|34</p>
+
+<!-- Shift+Right; the selection is now left-to-right. -->
+<p>12|3|4</p>
+
+<!-- Save and restore the selection. -->
+
+<!--
+In browsers that support Selection#extend, the restored selection “knows” that
+it was left-to-right; pressing Shift-Left collapses the selection back to its
+origin:
+-->
+<p>12|34</p>
+
+<!--
+In Internet Explorer, because the selection has no directionality, the
+selection *always* gets extended:
+-->
+<p>1|23|4</p>
+```
+
+This problem will only manifest itself when saving and restoring the selection excessively often; be mindful of this issue, and try to save and restore the selection only when necessary.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "choice",
   "version": "1.4.0",
   "description": "A module for working with selections in contenteditable areas.",
-  "main": "src/choice.js",
+  "main": "lib/choice.js",
   "scripts": {
     "test": "make test"
   },
@@ -23,22 +23,18 @@
   "bugs": {
     "url": "https://github.com/lucthev/choice/issues"
   },
-  "standard": {
-    "ignore": [
-      "dist/**/*.js"
-    ]
-  },
   "homepage": "https://github.com/lucthev/choice",
   "devDependencies": {
-    "browserify": "9.0.3",
+    "babel": "^5.8.23",
+    "browserify": "^11.0.1",
     "jasmine-core": "2.2.0",
     "karma": "0.12.31",
     "karma-chrome-launcher": "0.1.7",
     "karma-cli": "0.0.4",
     "karma-jasmine": "0.3.5",
     "karma-sauce-launcher": "0.2.10",
-    "standard": "^3.2.0",
-    "uglify-js": "2.4.16"
+    "standard": "^5.2.1",
+    "uglify-js": "^2.4.24"
   },
   "dependencies": {
     "block-elements": "^1.0.0"

--- a/src/choice.js
+++ b/src/choice.js
@@ -84,7 +84,7 @@ Choice.prototype.restore = function (selection) {
 
   children = this._getChildren()
 
-  if (selection.isCollapsed()) {
+  if (selection.isCollapsed) {
     start = decodePosition(children[selection.end[0]], selection.end[1])
   } else {
     start = decodePosition(children[selection.start[0]], selection.start[1])

--- a/src/decode.js
+++ b/src/decode.js
@@ -1,6 +1,4 @@
-'use strict'
-
-var utils = require('./utils')
+import {isElem, toArray} from './utils'
 
 /**
  * decodePosition(root, offset) returns the node and the offset within
@@ -15,17 +13,15 @@ var utils = require('./utils')
  * }
  */
 function decodePosition (root, offset) {
-  var node = root.firstChild
-  var depth = 0
-  var children
-  var parent
+  let node = root.firstChild
+  let depth = 0
 
   while (node) {
-    if (utils.isElem(node)) {
+    if (isElem(node)) {
       if (node.nodeName === 'BR') {
         if (!offset) {
-          parent = node.parentNode
-          children = utils.toArray(parent.childNodes)
+          let parent = node.parentNode
+          let children = toArray(parent.childNodes)
 
           return { node: parent, offset: children.indexOf(node) }
         }
@@ -51,7 +47,7 @@ function decodePosition (root, offset) {
     }
 
     if (offset <= node.data.length) {
-      return { node: node, offset: offset }
+      return { node, offset }
     }
 
     offset -= node.data.length
@@ -67,7 +63,7 @@ function decodePosition (root, offset) {
   }
 
   // We shouldn't reach here, in theory.
-  throw new Error('Invalid selection indices.')
+  throw RangeError('Invalid selection indices.')
 }
 
-module.exports = decodePosition
+export default decodePosition

--- a/src/encode.js
+++ b/src/encode.js
@@ -1,6 +1,4 @@
-'use strict'
-
-var utils = require('./utils')
+import {isElem, isBlock, isText} from './utils'
 
 /**
  * isLastChild(root, node) determines if the Node node is the last
@@ -34,7 +32,7 @@ function isLastChild (root, node) {
  * @return {Int}
  */
 function textBefore (root, node) {
-  var length = 0
+  let length = 0
 
   while (node && node !== root) {
     if (!node.previousSibling) {
@@ -44,11 +42,11 @@ function textBefore (root, node) {
 
     node = node.previousSibling
 
-    while (utils.isElem(node) && node.lastChild) {
+    while (isElem(node) && node.lastChild) {
       node = node.lastChild
     }
 
-    if (utils.isText(node)) {
+    if (isText(node)) {
       length += node.data.length
     } else if (node.nodeName === 'BR') {
       // <br>s count as a newline character.
@@ -70,13 +68,10 @@ function textBefore (root, node) {
  * @return {Array}
  */
 function encodePosition (children, node, offset) {
-  var lastBR = false
-  var childIndex
-  var textIndex
-  var child
+  let lastBR = false
 
   while (node) {
-    if (utils.isText(node) || node.nodeName === 'BR') {
+    if (isText(node) || node.nodeName === 'BR') {
       break
     } else if (!node.isContentEditable) {
       node = node.nextSibling
@@ -89,7 +84,7 @@ function encodePosition (children, node, offset) {
     } else {
       node = node.lastChild
 
-      if (utils.isText(node)) {
+      if (isText(node)) {
         offset = node.data.length
       } else if (node.nodeName === 'BR') {
         offset = 1
@@ -100,12 +95,12 @@ function encodePosition (children, node, offset) {
     }
   }
 
-  child = node
-  while (child.parentNode && !utils.isBlock(child)) {
+  let child = node
+  while (child.parentNode && !isBlock(child)) {
     child = child.parentNode
   }
 
-  childIndex = children.indexOf(child)
+  let childIndex = children.indexOf(child)
 
   // If the selection is not in the root's tree, do nothing.
   if (childIndex < 0) return false
@@ -115,9 +110,9 @@ function encodePosition (children, node, offset) {
     offset -= 1
   }
 
-  textIndex = textBefore(child, node) + offset
+  let textIndex = textBefore(child, node) + offset
 
   return [childIndex, textIndex]
 }
 
-module.exports = encodePosition
+export default encodePosition

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,86 +1,82 @@
-'use strict'
-
-/**
- * Selection(start [, end]) holds information about a selection.
- *
- * @param {Array} start
- * @param {Array} end
- * @return {Selection}
- */
-function Selection (start, end) {
-  if (!(this instanceof Selection)) {
-    return new Selection(start, end)
+class Selection {
+  /**
+   * Selection(start[, end]) holds information about a selection.
+   *
+   * @param {Array} start
+   * @param {Array} end
+   */
+  constructor (start, end = start.slice()) {
+    this.start = start
+    this.end = end
   }
 
-  this.start = start
-  this.end = end || start.slice()
-}
-
-/**
- * absoluteStart() returns the endpoint that is first in document order.
- *
- * @return {Array}
- */
-Selection.prototype.absoluteStart = function () {
-  return this.isBackwards() ? this.end : this.start
-}
-
-/**
- * absoluteStart() returns the endpoint that is first in document order.
- *
- * @return {Array}
- */
-Selection.prototype.absoluteEnd = function () {
-  return this.isBackwards() ? this.start : this.end
-}
-
-/**
- * isCollapsed() determines if the Selection represents a collapsed
- * selection.
- *
- * @return {Boolean}
- */
-Selection.prototype.isCollapsed = function () {
-  return this.start[0] === this.end[0] && this.start[1] === this.end[1]
-}
-
-/**
- * isBackwards() determines if the Selection represents a backwards
- * selection.
- *
- * @return {Boolean}
- */
-Selection.prototype.isBackwards = function () {
-  return this.start[0] > this.end[0] ||
-    (this.start[0] === this.end[0] && this.start[1] > this.end[1])
-}
-
-/**
- * equals(other) determines if two selections are equivalent.
- *
- * @param {Selection} other
- * @return {Boolean}
- */
-Selection.prototype.equals = function (other) {
-  if (!(other instanceof Selection)) {
-    return false
+  /**
+   * absoluteStart is a getter that returns the endpoint that is first
+   * in document order.
+   *
+   * @return {Array}
+   */
+  get absoluteStart () {
+    return this.isBackwards ? this.end : this.start
   }
 
-  return (
-    this.start[0] === other.start[0] &&
-    this.start[1] === other.start[1] &&
-    this.end[0] === other.end[0] &&
-    this.end[1] === other.end[1]
-  )
-}
+  /**
+   * absoluteEnd is a getter that returns the endpoint that is last
+   * in document order.
+   *
+   * @return {Array}
+   */
+  get absoluteEnd () {
+    return this.isBackwards ? this.start : this.end
+  }
 
-/**
- * clone() returns a Selection identical to that it was called on.
- *
- * @return {Selection}
- */
-Selection.prototype.clone = function () {
-  return new Selection(this.start.slice(), this.end.slice())
+  /**
+   * isCollapsed is a getter that determines if the Selection represents a
+   * collapsed selection.
+   *
+   * @return {Boolean}
+   */
+  get isCollapsed () {
+    return this.start[0] === this.end[0] && this.start[1] === this.end[1]
+  }
+
+  /**
+   * isBackwards is a getter that determines if the Selection represents a
+   * backwards selection.
+   *
+   * @return {Boolean}
+   */
+  get isBackwards () {
+    return this.start[0] > this.end[0] ||
+      (this.start[0] === this.end[0] && this.start[1] > this.end[1])
+  }
+
+  /**
+   * equals(other) determines if two selections are equivalent.
+   *
+   * @param {Selection} other
+   * @return {Boolean}
+   */
+  equals (other) {
+    return (
+      other instanceof Selection &&
+      this.start[0] === other.start[0] &&
+      this.start[1] === other.start[1] &&
+      this.end[0] === other.end[0] &&
+      this.end[1] === other.end[1]
+    )
+  }
+
+  /**
+   * clone() returns a Selection identical to that it was called on.
+   *
+   * @return {Selection}
+   */
+  clone () {
+    // To allow subclassing.
+    let S = this.constructor
+    return new S(this.start.slice(), this.end.slice())
+  }
 }
 
 /**
@@ -100,4 +96,4 @@ Selection.equals = function (first, second) {
   return first instanceof Selection && first.equals(second)
 }
 
-module.exports = Selection
+export default Selection

--- a/src/selection.js
+++ b/src/selection.js
@@ -1,10 +1,10 @@
+/**
+ * Selection(start[, end]) holds information about a selection.
+ *
+ * @param {Array} start
+ * @param {Array} end
+ */
 class Selection {
-  /**
-   * Selection(start[, end]) holds information about a selection.
-   *
-   * @param {Array} start
-   * @param {Array} end
-   */
   constructor (start, end = start.slice()) {
     this.start = start
     this.end = end

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,34 +1,28 @@
-'use strict'
+import blockElements from 'block-elements'
 
-var blocks = require('block-elements').map(function (block) {
-  return block.toUpperCase()
-})
-
-if (blocks.indexOf('LI') < 0) {
-  blocks.push('LI')
-}
-
-exports.toArray = function (val) {
+export function toArray (val) {
   return [].slice.call(val)
 }
 
-exports.isText = function (node) {
+export function isText (node) {
   return node && node.nodeType === window.Node.TEXT_NODE
 }
 
-var isElem = exports.isElem = function (node) {
+export function isElem (node) {
   return node && node.nodeType === window.Node.ELEMENT_NODE
 }
 
-var blockRegex = new RegExp('^(' + blocks.join('|') + ')$')
+let blocks = { LI: true }
+blockElements.forEach(function (name) {
+  blocks[name.toUpperCase()] = true
+})
 
 /**
- * isBlock(elem) determines if an element is a visual block according
- * to the above RegExp.
+ * isBlock(elem) determines if an element is a visual block.
  *
  * @param {Node} elem
  * @return {Boolean}
  */
-exports.isBlock = function (elem) {
-  return isElem(elem) && blockRegex.test(elem.nodeName)
+export function isBlock (node) {
+  return node && blocks[node.nodeName]
 }

--- a/test/getSelection.spec.js
+++ b/test/getSelection.spec.js
@@ -16,8 +16,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 5]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('collapsed selection (2)', function () {
@@ -26,8 +26,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 0]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('collapsed selection (3)', function () {
@@ -36,8 +36,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 5]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('collapsed selection (4)', function () {
@@ -46,8 +46,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 8]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('collapsed selection (5)', function () {
@@ -56,8 +56,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 8]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('collapsed selection (6)', function () {
@@ -66,8 +66,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 9]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should treat <br>s as newlines (collapsed selection)', function () {
@@ -76,8 +76,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 9]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('<br>s, collapsed selection (2)', function () {
@@ -86,8 +86,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 8]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('<br>s, collapsed selection (3)', function () {
@@ -99,8 +99,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([2, 16]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should return the start and end points when selection is not collapsed', function () {
@@ -109,8 +109,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 0], [1, 3]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('not collapsed (2)', function () {
@@ -120,8 +120,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 3], [0, 0]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   it('not collapsed (3)', function () {
@@ -130,8 +130,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 3], [0, 4]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   it('not collapsed (4)', function () {
@@ -140,16 +140,16 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 5], [1, 6]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(false)
 
     placeCursor(elem, '<h1>Things</h1><p>Words|<br>|Stuff</p><p>More</p>', true)
 
     sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 6], [1, 5]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   xit('should account for edge cases', function () {
@@ -160,8 +160,8 @@ describe('Choice#getSelection', function () {
 
     expect(sel)
       .toEqual(new Selection([0, 14], [0, 8]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   it('edge cases (2)', function () {
@@ -171,16 +171,16 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 0]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
 
     placeCursor(elem, '<p>One</p><p>Two</p>|')
 
     sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 3]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('edge cases (3)', function () {
@@ -189,8 +189,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 3], [0, 0]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   it('edge cases (4)', function () {
@@ -199,24 +199,24 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 3]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
 
     placeCursor(elem, '<p>A <strong><em>b</em>|</strong> c</p>')
 
     sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 3]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
 
     placeCursor(elem, '<p>A <strong><em>b</em></strong>| c</p>')
 
     sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 3]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('Firefox selectall', function () {
@@ -225,8 +225,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 0]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('Firefox selectall (2)', function () {
@@ -236,8 +236,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([0, 0], [0, 5]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should return null when the cursor is not in the selection', function () {
@@ -285,16 +285,16 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 0]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
 
     placeCursor(elem, '<ul><li>One</li><li>Two|</li><li>Three</li></ul>')
 
     sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 3]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should consider list items as blocks (2)', function () {
@@ -303,8 +303,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 7]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should consider list items as blocks (3)', function () {
@@ -313,8 +313,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([1, 7]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should consider list items as blocks (4)', function () {
@@ -325,8 +325,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([2, 1]))
-    expect(sel.isCollapsed()).toBe(true)
-    expect(sel.isBackwards()).toBe(false)
+    expect(sel.isCollapsed).toBe(true)
+    expect(sel.isBackwards).toBe(false)
   })
 
   it('should consider list items as blocks (5)', function () {
@@ -338,8 +338,8 @@ describe('Choice#getSelection', function () {
     var sel = choice.getSelection()
 
     expect(sel).toEqual(new Selection([3, 3], [0, 0]))
-    expect(sel.isCollapsed()).toBe(false)
-    expect(sel.isBackwards()).toBe(true)
+    expect(sel.isCollapsed).toBe(false)
+    expect(sel.isBackwards).toBe(true)
   })
 
   function setup () {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine'],
     reporters: ['dots'],
     files: [
-      '../dist/choice.js',
+      '../choice.min.js',
       './utils.js',
       './*.spec.js'
     ],

--- a/test/selection.spec.js
+++ b/test/selection.spec.js
@@ -49,15 +49,15 @@ describe('Selection', function () {
     var forward = new Selection([1, 2], [3, 4])
     var backward = new Selection([3, 4], [1, 2])
 
-    expect(forward.absoluteStart()).toEqual(forward.start)
-    expect(backward.absoluteStart()).toEqual(backward.end)
+    expect(forward.absoluteStart).toEqual(forward.start)
+    expect(backward.absoluteStart).toEqual(backward.end)
   })
 
   it('#absoluteEnd returns the last endpoint', function () {
     var forward = new Selection([1, 2], [3, 4])
     var backward = new Selection([3, 4], [1, 2])
 
-    expect(forward.absoluteEnd()).toEqual(forward.end)
-    expect(backward.absoluteEnd()).toEqual(backward.start)
+    expect(forward.absoluteEnd).toEqual(forward.end)
+    expect(backward.absoluteEnd).toEqual(backward.start)
   })
 })


### PR DESCRIPTION
From the changelog:
## 2.0.0

This major release brings about a few API changes and wider browser support.

API changes are limited to Choice.Selection; the `absoluteStart`, `absoluteEnd`, `isCollapsed`, and `isBackwards` methods have instead been turned into getters. This means that the following code:

``` js
var c = new Choice(someElement)
var s = c.getSelection()

var isCollapsed = s.isCollapsed()
var isBackwards = s.isBackwards()
var absoluteStart = s.absoluteStart()
var absoluteEnd = s.absoluteEnd()
```

Should, in `v2` onwards, be written as:

``` js
var c = new Choice(someElement)
var s = c.getSelection()

var isCollapsed = s.isCollapsed // Not a function call
var isBackwards = s.isBackwards
var absoluteStart = s.absoluteStart
var absoluteEnd = s.absoluteEnd
```

Additionally, Choice now works in browsers without the native `Selection#extend` method (namely, Internet Explorer).
